### PR TITLE
Add line height control to email editor

### DIFF
--- a/src/components/editor/EditorToolbar.tsx
+++ b/src/components/editor/EditorToolbar.tsx
@@ -40,12 +40,23 @@ const FONT_SIZE_OPTIONS = [
   { label: '28 px', value: '28px' },
 ]
 
+const LINE_HEIGHT_OPTIONS = [
+  { label: 'Интерлиньяж', value: '' },
+  { label: '1.0', value: '1' },
+  { label: '1.2', value: '1.2' },
+  { label: '1.5', value: '1.5' },
+  { label: '1.75', value: '1.75' },
+  { label: '2.0', value: '2' },
+  { label: '2.5', value: '2.5' },
+]
+
 interface SelectionState {
   color: string | null
   fontSize: string | null
   fontFamily: string | null
   align: Alignment | null
   backgroundColor: string | null
+  lineHeight: string | null
 }
 
 interface EditorToolbarProps {
@@ -205,6 +216,15 @@ export const EditorToolbar: FC<EditorToolbarProps> = ({
     execute().setFontSize(value).run()
   }
 
+  const handleLineHeightChange = (event: ChangeEvent<HTMLSelectElement>) => {
+    const value = event.target.value
+    if (!value) {
+      execute().unsetLineHeight().run()
+      return
+    }
+    execute().setLineHeight(value).run()
+  }
+
   const handleFontFamilyChange = (event: ChangeEvent<HTMLSelectElement>) => {
     const value = event.target.value
     if (!value) {
@@ -345,6 +365,18 @@ export const EditorToolbar: FC<EditorToolbarProps> = ({
           aria-label="Размер шрифта"
         >
           {FONT_SIZE_OPTIONS.map((option) => (
+            <option key={option.value || 'default'} value={option.value}>
+              {option.label}
+            </option>
+          ))}
+        </select>
+        <select
+          className="editor-toolbar__select"
+          value={selectionState.lineHeight ?? ''}
+          onChange={handleLineHeightChange}
+          aria-label="Межстрочный интервал"
+        >
+          {LINE_HEIGHT_OPTIONS.map((option) => (
             <option key={option.value || 'default'} value={option.value}>
               {option.label}
             </option>
@@ -493,6 +525,7 @@ export const EditorToolbar: FC<EditorToolbarProps> = ({
               .unsetFontSize()
               .unsetFontFamily()
               .unsetBackgroundColor()
+              .unsetLineHeight()
               .unsetTextAlign()
               .run()
           }}

--- a/src/components/editor/EmailEditor.tsx
+++ b/src/components/editor/EmailEditor.tsx
@@ -16,9 +16,10 @@ import { PreviewPane } from './PreviewPane'
 import { FontSize } from './extensions/fontSize'
 import { FontFamily } from './extensions/fontFamily'
 import { BackgroundColor } from './extensions/backgroundColor'
+import { LineHeight } from './extensions/lineHeight'
 import { formatHtml } from '../../utils/formatHtml'
 import { normalizeHexColor } from '../../utils/colors'
-import { ALIGNMENTS, applyFormatting, captureFormatting } from './formatting'
+import { ALIGNMENTS, applyFormatting, captureFormatting, getActiveLineHeight } from './formatting'
 import type { FormattingSnapshot, ViewMode } from './types'
 import './EmailEditor.css'
 
@@ -28,6 +29,7 @@ type SelectionState = {
   fontFamily: string | null
   align: 'left' | 'center' | 'right' | 'justify' | null
   backgroundColor: string | null
+  lineHeight: string | null
 }
 
 const AUTOSAVE_STORAGE_KEY = 'wysiwyg-email-autosave'
@@ -52,6 +54,7 @@ export const EmailEditor = () => {
     fontFamily: '',
     align: 'left',
     backgroundColor: 'transparent',
+    lineHeight: '',
   })
   const [formatSnapshot, setFormatSnapshot] = useState<FormattingSnapshot | null>(null)
   const [autosaveTimestamp, setAutosaveTimestamp] = useState<number | null>(null)
@@ -90,6 +93,7 @@ export const EmailEditor = () => {
         FontSize,
         FontFamily,
         BackgroundColor,
+        LineHeight,
         TextAlign.configure({
           types: ['heading', 'paragraph', 'image'],
         }),
@@ -147,6 +151,7 @@ export const EmailEditor = () => {
       const fontFamily = textStyle?.fontFamily ?? ''
       const backgroundColor = normalizeHexColor(textStyle?.backgroundColor) ?? 'transparent'
       const align = ALIGNMENTS.find((alignment) => editor.isActive({ textAlign: alignment })) ?? null
+      const lineHeight = getActiveLineHeight(editor) ?? ''
 
       setSelectionState({
         color,
@@ -154,6 +159,7 @@ export const EmailEditor = () => {
         fontFamily,
         align,
         backgroundColor,
+        lineHeight,
       })
     }
 

--- a/src/components/editor/extensions/lineHeight.ts
+++ b/src/components/editor/extensions/lineHeight.ts
@@ -1,0 +1,53 @@
+import { Extension } from '@tiptap/core'
+
+declare module '@tiptap/core' {
+  interface Commands<ReturnType> {
+    lineHeight: {
+      setLineHeight: (lineHeight: string) => ReturnType
+      unsetLineHeight: () => ReturnType
+    }
+  }
+}
+
+const BLOCK_TYPES = ['paragraph', 'heading'] as const
+
+export const LineHeight = Extension.create({
+  name: 'lineHeight',
+
+  addGlobalAttributes() {
+    return [
+      {
+        types: Array.from(BLOCK_TYPES),
+        attributes: {
+          lineHeight: {
+            default: null,
+            parseHTML: (element: HTMLElement) => element.style.lineHeight || null,
+            renderHTML: (attributes: Record<string, any>) => {
+              const lineHeight = attributes.lineHeight as string | null | undefined
+              if (!lineHeight) {
+                return {}
+              }
+
+              return {
+                style: `line-height: ${lineHeight}`,
+              }
+            },
+          },
+        },
+      },
+    ]
+  },
+
+  addCommands() {
+    return {
+      setLineHeight:
+        (lineHeight: string) =>
+        ({ commands }) =>
+          BLOCK_TYPES.some((type) => commands.updateAttributes(type, { lineHeight })),
+      unsetLineHeight:
+        () =>
+        ({ commands }) =>
+          BLOCK_TYPES.some((type) => commands.updateAttributes(type, { lineHeight: null })),
+    }
+  },
+})

--- a/src/components/editor/types.ts
+++ b/src/components/editor/types.ts
@@ -9,6 +9,7 @@ export type FormattingSnapshot = {
   fontFamily?: string | null
   align?: 'left' | 'center' | 'right' | 'justify' | null
   backgroundColor?: string | null
+  lineHeight?: string | null
   link?: string | null
   blockType?:
     | { type: 'paragraph' }


### PR DESCRIPTION
## Summary
- add a dedicated TipTap extension to manage line-height attributes on paragraphs and headings
- surface a line-height selector in the toolbar and keep formatting snapshots in sync with the new setting

## Testing
- npm run lint
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68ced2748ad883328d4a190886a97fc8